### PR TITLE
Add option `.comment.glob-options`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add a new config option `.comment.glob-options` which forwards options to the glob matching library. This allows for example to turn off case-sensitivity of the globs or also match hidden files and directories with `**`. 
+
 ## 1.0.0 (2021-04-11)
 
 - Initial release

--- a/README.md
+++ b/README.md
@@ -149,6 +149,19 @@ comment:
 
 **Required**: true
 
+#### `comment.glob-options`
+
+This GitHub action uses the [minimatch](https://github.com/isaacs/minimatch) library for glob matching. To modify the behavior of this library, an options object can be provided. See [the list of minimatch options](https://github.com/isaacs/minimatch#options) for more details.
+
+Example:
+
+```yaml
+# Make all globs also match hidden files and directories
+comment:
+  glob-options:
+    dot: true
+```
+
 ## Development
 
 ### Setup

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ comment:
 
 #### `comment.glob-options`
 
-This GitHub action uses the [minimatch](https://github.com/isaacs/minimatch) library for glob matching. To modify the behavior of this library, an options object can be provided. See [the list of minimatch options](https://github.com/isaacs/minimatch#options) for more details.
+This GitHub action uses the [minimatch](https://github.com/isaacs/minimatch) library for glob matching. A object with options can be provided under `comment.glob-options` to modify the behavior of this library. See [the list of minimatch options](https://github.com/isaacs/minimatch#options) for the list of supported options.
 
 Example:
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,6 +26,10 @@ function validateCommentConfig(configObject) {
     );
   }
 
+  if (configObject.comment['glob-options'] && typeof configObject.comment['glob-options'] === 'object') {
+    configMap.set('globOptions', configObject.comment['glob-options']);
+  }
+
   if (configObject.comment.footer === undefined || configObject.comment.footer === null || typeof configObject.comment.footer === 'string') {
     configMap.set('footer', configObject.comment.footer);
   } else {

--- a/lib/snippets.js
+++ b/lib/snippets.js
@@ -5,7 +5,7 @@ function getMatchingSnippetIds(changedFiles, commentConfig) {
   const snippetIds = commentConfig.get('snippets').reduce((acc, snippet) => {
     core.debug(`processing snippet ${snippet.get('id')}`);
 
-    if (checkGlobs(changedFiles, snippet.get('files'))) {
+    if (checkGlobs(changedFiles, snippet.get('files'), commentConfig.get('globOptions') || {})) {
       return [...acc, snippet.get('id')];
     }
     return acc;
@@ -30,11 +30,11 @@ function printPattern(matcher) {
   return (matcher.negate ? '!' : '') + matcher.pattern;
 }
 
-function checkGlobs(changedFiles, globs) {
+function checkGlobs(changedFiles, globs, opts) {
   for (const glob of globs) {
     core.debug(` checking pattern ${JSON.stringify(glob)}`);
     const matchConfig = toMatchConfig(glob);
-    if (checkMatch(changedFiles, matchConfig)) {
+    if (checkMatch(changedFiles, matchConfig, opts)) {
       return true;
     }
   }
@@ -56,8 +56,8 @@ function isMatch(changedFile, matchers) {
 }
 
 // equivalent to "Array.some()" but expanded for debugging and clarity
-function checkAny(changedFiles, globs) {
-  const matchers = globs.map((g) => new Minimatch(g));
+function checkAny(changedFiles, globs, opts) {
+  const matchers = globs.map((g) => new Minimatch(g, opts));
   core.debug('  checking "any" patterns');
   for (const changedFile of changedFiles) {
     if (isMatch(changedFile, matchers)) {
@@ -71,8 +71,8 @@ function checkAny(changedFiles, globs) {
 }
 
 // equivalent to "Array.every()" but expanded for debugging and clarity
-function checkAll(changedFiles, globs) {
-  const matchers = globs.map((g) => new Minimatch(g));
+function checkAll(changedFiles, globs, opts) {
+  const matchers = globs.map((g) => new Minimatch(g, opts));
   core.debug(' checking "all" patterns');
   for (const changedFile of changedFiles) {
     if (!isMatch(changedFile, matchers)) {
@@ -85,15 +85,15 @@ function checkAll(changedFiles, globs) {
   return true;
 }
 
-function checkMatch(changedFiles, matchConfig) {
+function checkMatch(changedFiles, matchConfig, opts) {
   if (matchConfig.all !== undefined) {
-    if (!checkAll(changedFiles, matchConfig.all)) {
+    if (!checkAll(changedFiles, matchConfig.all, opts)) {
       return false;
     }
   }
 
   if (matchConfig.any !== undefined) {
-    if (!checkAny(changedFiles, matchConfig.any)) {
+    if (!checkAny(changedFiles, matchConfig.any, opts)) {
       return false;
     }
   }

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -190,7 +190,7 @@ describe('validateCommentConfig', () => {
     expect(() => config.validateCommentConfig(input)).toThrow(/found unexpected value 'whatever' under key '\.comment\.on-update' \(should be one of: recreate, edit, nothing\)/);
   });
 
-  test('glob-options is an optional', () => {
+  test('glob-options is optional', () => {
     const input = {
       comment: {
         'glob-options': {

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -190,6 +190,31 @@ describe('validateCommentConfig', () => {
     expect(() => config.validateCommentConfig(input)).toThrow(/found unexpected value 'whatever' under key '\.comment\.on-update' \(should be one of: recreate, edit, nothing\)/);
   });
 
+  test('glob-options is an optional', () => {
+    const input = {
+      comment: {
+        'glob-options': {
+          dot: true,
+          noglobstar: true,
+        },
+        snippets: [snippet1Object],
+      },
+    };
+
+    const output = new Map([
+      ['onUpdate', 'recreate'],
+      ['header', undefined],
+      ['footer', undefined],
+      ['globOptions', {
+        dot: true,
+        noglobstar: true,
+      }],
+      ['snippets', [snippet1Map]],
+    ]);
+
+    expect(config.validateCommentConfig(input)).toEqual(output);
+  });
+
   test('snippets is required', () => {
     const input = {
       comment: {},


### PR DESCRIPTION
Closes #1 

To get more bang for the buck (less work, more features 😬) I decided to just pass an options object as given to the library. That would allow people to modify other kind of glob matching behavior, not only how dot files are treated.