### PR TITLE
Add support for Mustache templates in snippet ids

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Add support for Mustache templates in snippet ids. This allows more control over when a comment will be recreated. 
+
 ## 1.2.0 (2021-07-31)
 
 - Add support for Mustache templates in comments.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,9 @@ A list of comment snippet configurations. At least one snippet is required. Note
 
 #### `comment.snippets[].id`
 
-A string consisting of letters, numbers, `-`, and `_`.
+A string consisting of letters, numbers, `-`, and `_` or a Mustache template that evaluates to such a string.
+
+_Snippet ids are used to check whether a comment's content changed. If you're using a template variable in the snippets's body and you want to recreate the whole comment when that variable changes value, use it in the snippet's id too._ 
 
 **Required**: true
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Variables for the template can be provided via the `template-variables` input wh
 
 You can use the [context and expression syntax](https://docs.github.com/en/actions/reference/context-and-expression-syntax-for-github-actions) to assemble the JSON and [set-output](https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#setting-an-output-parameter) to calculate data for the template in separate steps.
 
-###### Example
+###### Example 1
 
 ```yaml
 name: "PR Commenter"
@@ -153,6 +153,49 @@ comment:
 ```
 
 Note that values such as the PR's title, body, or branch name should be considered [unsafe user input](https://docs.github.com/en/actions/learn-github-actions/security-hardening-for-github-actions#understanding-the-risk-of-script-injections).
+
+###### Example 2
+
+Here's a more complex example of using template variables. Let's say you have a multiline file that changes often, and you want to always include the newest content of the file in the snippet.
+
+To ensure the comment will be recreated when the file changes, use the file's hash in the snippet's id.
+
+To ensure that newline characters are handled correctly, use environment variables instead of job outputs and `toJSON`.
+
+```yaml
+name: "PR Commenter"
+on:
+  - pull_request_target
+
+jobs:
+  pr-comment:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set environment variables
+        run: |
+          IMPORTANT_FILE_CONTENT=$(cat important_file)
+          echo "IMPORTANT_FILE_CONTENT<<EOF" >> $GITHUB_ENV
+          echo "$IMPORTANT_FILE_CONTENT" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
+
+      - uses: exercism/pr-commenter-action@v1.1.0
+        with:
+          template-variables: |
+            {
+              "importantFileContent": ${{ toJSON(env.IMPORTANT_FILE_CONTENT) }},
+              "importnatFileHash": ${{ toJSON(hashFiles('important_file.txt')) }}
+            }
+```
+```yaml
+comment:
+  snippets:
+    - id: snippet_{{ importnatFileHash }}}
+    - files:
+      - 'important_file.txt'
+    - body: |
+        This is very important:
+        {{ importantFileContent }}
+```
 
 #### `comment.snippets[].files`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,4 +1,6 @@
-function validateCommentConfig(configObject) {
+const Mustache = require('mustache');
+
+function validateCommentConfig(configObject, templateVariables) {
   const configMap = new Map();
 
   if (typeof configObject.comment !== 'object') {
@@ -43,12 +45,13 @@ function validateCommentConfig(configObject) {
       const snippetMap = new Map();
 
       if (typeof snippetObject.id === 'string') {
+        const id = Mustache.render(snippetObject.id, templateVariables);
         const regex = /^[A-Za-z0-9\-_,]*$/;
-        if (regex.exec(snippetObject.id)) {
-          snippetMap.set('id', snippetObject.id);
+        if (regex.exec(id)) {
+          snippetMap.set('id', id);
         } else {
           throw Error(
-            `found invalid snippet id '${snippetObject.id}' (snippet ids must contain only letters, numbers, dashes, and underscores)`,
+            `found invalid snippet id '${id}' (snippet ids must contain only letters, numbers, dashes, and underscores)`,
           );
         }
       } else {

--- a/lib/run.js
+++ b/lib/run.js
@@ -38,9 +38,6 @@ async function run() {
 
   core.debug(`fetching changed files for pr #${prNumber}`);
   const changedFiles = await getChangedFiles(client, prNumber);
-  const commentConfig = await getCommentConfig(client, configPath);
-
-  const snippetIds = getMatchingSnippetIds(changedFiles, commentConfig);
   const previousComment = await getPreviousPRComment(client, prNumber);
 
   let templateVariables = {};
@@ -56,6 +53,9 @@ async function run() {
   } else {
     core.debug('Input template-variables was not passed');
   }
+
+  const commentConfig = await getCommentConfig(client, configPath, templateVariables);
+  const snippetIds = getMatchingSnippetIds(changedFiles, commentConfig);
 
   if (shouldDeletePreviousComment(previousComment, snippetIds, commentConfig)) {
     core.info('removing previous comment');
@@ -84,12 +84,12 @@ function getPrNumber() {
   return pullRequest.number;
 }
 
-async function getCommentConfig(client, configurationPath) {
+async function getCommentConfig(client, configurationPath, templateVariables) {
   const configurationContent = await getFileContent(client, configurationPath);
   const configObject = yaml.load(configurationContent);
 
   // transform object to a map or throw if yaml is malformed:
-  const configMap = validateCommentConfig(configObject);
+  const configMap = validateCommentConfig(configObject, templateVariables);
   return configMap;
 }
 


### PR DESCRIPTION
This PR allows using variables in snippet ids to allow forcing recreating the comment more often. Comments are only recreated when which snippets were matched changed. Without variables in snippet ids, that only means a comment will get recreated when the list of files edited in the PR changes. By adding a variable to the id, the user can force the comment to get recreated more often, e.g. when the content of a specific file changes by using the file's hash or always by using a timestamp.

I'm making this change because we need it at https://github.com/steady-media, in particular exactly this case that I described in the new example:

> Here's a more complex example of using template variables. Let's say you have a multiline file that changes often, and you want to always include the newest content of the file in the snippet.