### PR TITLE
Fixes repo-token --> github-token

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ comment:
 
 ### Workflow inputs
 
-#### `repo-token`
+#### `github-token`
 
 Auth token used to manage issues or pull requests.
 


### PR DESCRIPTION
Love your action :)
Just noticed this minor issue while I was using it, where the lower half of the docs says to pass in `repo-token` but your [`action.yml`](https://github.com/exercism/pr-commenter-action/blob/main/action.yml#L5) file, [`run.js`](https://github.com/exercism/pr-commenter-action/blob/main/lib/run.js#L25) script and first example say `github-token`.

So here's just a quick PR to update the second example so that it's consistent, in case anyone else gets the `Error: Input required and not supplied: github-token` error that I got earlier.