### PR TITLE
When looking for a previous comment made by this action, do not filter out non-bot users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Add support for Mustache templates in snippet ids. This allows more control over when a comment will be recreated. 
+- When looking for a previous comment made by this action, do not filter out non-bot users. This allows the action to correctly update or recreate comments when used with a token belonging to a real user.
 
 ## 1.2.0 (2021-07-31)
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -95,10 +95,11 @@ async function getCommentConfig(client, configurationPath, templateVariables) {
 
 async function getPreviousPRComment(client, prNumber) {
   const comments = await getComments(client, prNumber);
+  core.debug(`there are ${comments.length} comments on the PR #${prNumber}`);
 
   const newestFirst = (c1, c2) => c2.created_at.localeCompare(c1.created_at);
-  const botComments = comments.filter((c) => c.user.type === 'Bot').sort(newestFirst);
-  const previousComment = botComments.find((c) => extractCommentMetadata(c.body) !== null);
+  const sortedComments = comments.sort(newestFirst);
+  const previousComment = sortedComments.find((c) => extractCommentMetadata(c.body) !== null);
 
   if (previousComment) {
     const previousSnippetIds = extractCommentMetadata(previousComment.body);

--- a/test/run.test.js
+++ b/test/run.test.js
@@ -57,17 +57,15 @@ describe('run', () => {
     });
 
     const previousComment = {
-      user: { type: 'Bot' },
       created_at: '2020-01-03',
       body: comment.commentMetadata(['snippet3']),
       url: 'previous-comment-url',
     };
 
     const existingPRComments = [
-      { user: { type: 'user' } },
-      { user: { type: 'Bot' }, created_at: '2020-01-02' },
+      { created_at: '2020-01-02' },
       previousComment,
-      { user: { type: 'Bot' }, created_at: '2020-01-01' },
+      { created_at: '2020-01-01' },
     ];
 
     const commentBody = `${'Hello Bob!\n\n'


### PR DESCRIPTION
This will fix the second problem described in https://github.com/exercism/pr-commenter-action/issues/16